### PR TITLE
Bug 1971083 - Add support for type operators.

### DIFF
--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.semanticdb_kotlinc
 
 import java.nio.file.Path
 import kotlin.contracts.ExperimentalContracts
+import kotlin.math.exp
 import org.jetbrains.kotlin.*
 import org.jetbrains.kotlin.com.intellij.lang.LighterASTNode
 import org.jetbrains.kotlin.com.intellij.util.diff.FlyweightCapableTreeStructure
@@ -11,18 +12,26 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.*
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirBasicExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirClassReferenceExpressionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirQualifiedAccessExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirTypeOperatorCallChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.analysis.checkers.toClassLikeSymbol
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.expressions.FirClassReferenceExpression
 import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
+import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.toClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -47,6 +56,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                 override val qualifiedAccessExpressionCheckers:
                     Set<FirQualifiedAccessExpressionChecker> =
                     setOf(SemanticQualifiedAccessExpressionChecker())
+
+                override val typeOperatorCallCheckers:
+                        Set<SemanticClassReferenceExpressionChecker> = setOf(SemanticClassReferenceExpressionChecker())
             }
 
     open class AnalyzerDeclarationCheckers(sourceroot: Path) : DeclarationCheckers() {
@@ -404,6 +416,24 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                     visitor?.visitCallableReference(it, getIdentifier(calleeReference.source ?: source), context)
                 }
             }
+        }
+    }
+
+    private class SemanticClassReferenceExpressionChecker :
+        FirTypeOperatorCallChecker(MppCheckerKind.Common) {
+        @OptIn(ExperimentalContracts::class)
+        override fun check(
+            expression: FirTypeOperatorCall,
+            context: CheckerContext,
+            reporter: DiagnosticReporter
+        ) {
+            val typeRef = expression.conversionTypeRef
+            val source = typeRef.source ?: return
+            val classSymbol = expression.conversionTypeRef.toClassLikeSymbol(context.session) ?: return
+            val ktFile = context.containingFile?.sourceFile ?: return
+            val visitor = visitors[ktFile]
+
+            visitor?.visitClassReference(classSymbol, getIdentifier(expression.conversionTypeRef.source ?: source), context)
         }
     }
 }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -681,6 +681,50 @@ class AnalyzerTest {
     }
 
     @Test
+    fun `type operators`(@TempDir path: Path) {
+        val document =
+            compileSemanticdb(
+                path,
+                """
+            package sample
+
+            fun foo(x: Any) {
+                when (x) {
+                    is Int -> true
+                    else -> x as Float
+                }
+            }
+            """)
+
+        val occurrences =
+            arrayOf(
+                SymbolOccurrence {
+                    role = Role.REFERENCE
+                    symbol = "kotlin/Int#"
+                    range {
+                        startLine = 4
+                        startCharacter = 11
+                        endLine = 4
+                        endCharacter = 14
+                    }
+                },
+                SymbolOccurrence {
+                    role = Role.REFERENCE
+                    symbol = "kotlin/Float#"
+                    range {
+                        startLine = 5
+                        startCharacter = 21
+                        endLine = 5
+                        endCharacter = 26
+                    }
+                },
+            )
+        assertSoftly(document.occurrencesList) {
+            withClue(this) { occurrences.forEach(::shouldContain) }
+        }
+    }
+
+    @Test
     fun `exception test`(@TempDir path: Path) {
         val buildPath = File(path.resolve("build").toString()).apply { mkdir() }
         val result =


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1971083

This adds support for emitting type references in type operators:
- `is Type`
- `!is Type`
- `as Type`
- `as? Type`

### Test plan

New autotest