### PR TITLE
Update to Kotlin 2.2.20-RC2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    kotlin("jvm") version "2.2.0"
+    kotlin("jvm") version "2.2.20-RC2"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.diffplug.spotless") version "5.17.1"
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
@@ -137,7 +137,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
 
                 if (names != null) {
                     eachFqNameElement(fqName, source.treeStructure, names) { fqName, name ->
-                        visitor?.visitPackage(fqName, name, context)
+                        visitor?.visitPackage(fqName, name)
                     }
                 }
             }
@@ -158,13 +158,13 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                                 fqName.parent(), fqName.shortName())
 
                         if (klass != null) {
-                            visitor?.visitClassReference(klass, name, context)
+                            visitor?.visitClassReference(klass, name)
                         } else if (callables.isNotEmpty()) {
                             for (callable in callables) {
-                                visitor?.visitCallableReference(callable, name, context)
+                                visitor?.visitCallableReference(callable, name)
                             }
                         } else {
-                            visitor?.visitPackage(fqName, name, context)
+                            visitor?.visitPackage(fqName, name)
                         }
                     }
                 }
@@ -177,7 +177,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirClassLikeDeclaration) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
             val objectKeyword = if (declaration is FirAnonymousObject) {
                 source
@@ -187,14 +187,14 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
             } else {
                 null
             }
-            visitor?.visitClassOrObject(declaration, objectKeyword ?: getIdentifier(source), context)
+            visitor?.visitClassOrObject(declaration, objectKeyword ?: getIdentifier(source))
 
             if (declaration is FirClass) {
                 for (superType in declaration.superTypeRefs) {
                     val superSymbol = superType.toClassLikeSymbol(context.session)
                     val superSource = superType.source
                     if (superSymbol != null && superSource != null) {
-                        visitor?.visitClassReference(superSymbol, superSource, context)
+                        visitor?.visitClassReference(superSymbol, superSource)
                     }
                 }
             }
@@ -206,7 +206,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirConstructor) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
 
             if (declaration.isPrimary) {
@@ -229,9 +229,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                     null
                 }
 
-                visitor?.visitPrimaryConstructor(declaration, constructorKeyboard ?: objectKeyword ?: getIdentifier(klassSource), context)
+                visitor?.visitPrimaryConstructor(declaration, constructorKeyboard ?: objectKeyword ?: getIdentifier(klassSource))
             } else {
-                visitor?.visitSecondaryConstructor(declaration, getIdentifier(source), context)
+                visitor?.visitSecondaryConstructor(declaration, getIdentifier(source))
             }
         }
     }
@@ -241,14 +241,14 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirSimpleFunction) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitNamedFunction(declaration, getIdentifier(source), context)
+            visitor?.visitNamedFunction(declaration, getIdentifier(source))
 
             val klass = declaration.returnTypeRef.toClassLikeSymbol(context.session)
             val klassSource = declaration.returnTypeRef.source
             if (klass != null && klassSource != null && klassSource.kind !is KtFakeSourceElementKind) {
-                visitor?.visitClassReference(klass, getIdentifier(klassSource), context)
+                visitor?.visitClassReference(klass, getIdentifier(klassSource))
             }
         }
     }
@@ -259,9 +259,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirAnonymousFunction) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitNamedFunction(declaration, source, context)
+            visitor?.visitNamedFunction(declaration, source)
         }
     }
 
@@ -270,14 +270,14 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirProperty) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitProperty(declaration, getIdentifier(source), context)
+            visitor?.visitProperty(declaration, getIdentifier(source))
 
             val klass = declaration.returnTypeRef.toClassLikeSymbol(context.session)
             val klassSource = declaration.returnTypeRef.source
             if (klass != null && klassSource != null && klassSource.kind !is KtFakeSourceElementKind) {
-                visitor?.visitClassReference(klass, getIdentifier(klassSource), context)
+                visitor?.visitClassReference(klass, getIdentifier(klassSource))
             }
         }
     }
@@ -287,14 +287,14 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirValueParameter) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitParameter(declaration, getIdentifier(source), context)
+            visitor?.visitParameter(declaration, getIdentifier(source))
 
             val klass = declaration.returnTypeRef.toClassLikeSymbol(context.session)
             val klassSource = declaration.returnTypeRef.source
             if (klass != null && klassSource != null && klassSource.kind !is KtFakeSourceElementKind) {
-                visitor?.visitClassReference(klass, getIdentifier(klassSource), context)
+                visitor?.visitClassReference(klass, getIdentifier(klassSource))
             }
         }
     }
@@ -304,9 +304,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirTypeParameter) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitTypeParameter(declaration, getIdentifier(source), context)
+            visitor?.visitTypeParameter(declaration, getIdentifier(source))
         }
     }
 
@@ -315,9 +315,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirTypeAlias) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitTypeAlias(declaration, getIdentifier(source), context)
+            visitor?.visitTypeAlias(declaration, getIdentifier(source))
         }
     }
 
@@ -327,7 +327,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
         context(context: CheckerContext, reporter: DiagnosticReporter)
         override fun check(declaration: FirPropertyAccessor) {
             val source = declaration.source ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
             val identifierSource =
                 if (declaration.isGetter) {
@@ -346,7 +346,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                     getIdentifier(source)
                 }
 
-            visitor?.visitPropertyAccessor(declaration, identifierSource, context)
+            visitor?.visitPropertyAccessor(declaration, identifierSource)
         }
     }
 
@@ -361,25 +361,25 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
                 return
             }
 
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
-            visitor?.visitSimpleNameExpression(calleeReference, getIdentifier(calleeReference.source ?: source), context)
+            visitor?.visitSimpleNameExpression(calleeReference, getIdentifier(calleeReference.source ?: source))
 
             val resolvedSymbol = calleeReference.resolvedSymbol
             if (resolvedSymbol.origin == FirDeclarationOrigin.SamConstructor && resolvedSymbol is FirSyntheticFunctionSymbol) {
                 val referencedKlass = resolvedSymbol.resolvedReturnType.toClassLikeSymbol(context.session)
                 if (referencedKlass != null) {
-                    visitor?.visitClassReference(referencedKlass, getIdentifier(calleeReference.source ?: source), context)
+                    visitor?.visitClassReference(referencedKlass, getIdentifier(calleeReference.source ?: source))
                 }
             }
 
             // When encountering a reference to a property symbol, emit both getter and setter symbols
             if (resolvedSymbol is FirPropertySymbol) {
                 resolvedSymbol.getterSymbol?.let {
-                    visitor?.visitCallableReference(it, getIdentifier(calleeReference.source ?: source), context)
+                    visitor?.visitCallableReference(it, getIdentifier(calleeReference.source ?: source))
                 }
                 resolvedSymbol.setterSymbol?.let {
-                    visitor?.visitCallableReference(it, getIdentifier(calleeReference.source ?: source), context)
+                    visitor?.visitCallableReference(it, getIdentifier(calleeReference.source ?: source))
                 }
             }
         }
@@ -393,10 +393,10 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
             val typeRef = expression.conversionTypeRef
             val source = typeRef.source ?: return
             val classSymbol = expression.conversionTypeRef.toClassLikeSymbol(context.session) ?: return
-            val ktFile = context.containingFile?.sourceFile ?: return
+            val ktFile = context.containingFileSymbol?.sourceFile ?: return
             val visitor = visitors[ktFile]
 
-            visitor?.visitClassReference(classSymbol, getIdentifier(expression.conversionTypeRef.source ?: source), context)
+            visitor?.visitClassReference(classSymbol, getIdentifier(expression.conversionTypeRef.source ?: source))
         }
     }
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbVisitor.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbVisitor.kt
@@ -33,13 +33,13 @@ class SemanticdbVisitor(
         return documentBuilder.build()
     }
 
+    context(context: CheckerContext)
     private fun Sequence<SymbolDescriptorPair>?.emitAll(
         element: KtSourceElement,
         role: Role,
-        context: CheckerContext,
     ): List<Symbol>? =
         this?.onEach { (firBasedSymbol, symbol) ->
-                documentBuilder.emitSemanticdbData(firBasedSymbol, symbol, element, role, context)
+                documentBuilder.emitSemanticdbData(firBasedSymbol, symbol, element, role)
             }
             ?.map { it.symbol }
             ?.toList()
@@ -47,67 +47,80 @@ class SemanticdbVisitor(
     private fun Sequence<Symbol>.with(firBasedSymbol: FirBasedSymbol<*>?) =
         this.map { SymbolDescriptorPair(firBasedSymbol, it) }
 
-    fun visitPackage(pkg: FqName, element: KtSourceElement, context: CheckerContext) {
-        cache[pkg].with(null).emitAll(element, Role.REFERENCE, context)
+    context(context: CheckerContext)
+    fun visitPackage(pkg: FqName, element: KtSourceElement) {
+        cache[pkg].with(null).emitAll(element, Role.REFERENCE)
     }
 
-    fun visitClassReference(firClassSymbol: FirClassLikeSymbol<*>, element: KtSourceElement, context: CheckerContext) {
-        cache[firClassSymbol].with(firClassSymbol).emitAll(element, Role.REFERENCE, context)
+    context(context: CheckerContext)
+    fun visitClassReference(firClassSymbol: FirClassLikeSymbol<*>, element: KtSourceElement) {
+        cache[firClassSymbol].with(firClassSymbol).emitAll(element, Role.REFERENCE)
     }
 
-    fun visitCallableReference(firClassSymbol: FirCallableSymbol<*>, element: KtSourceElement, context: CheckerContext) {
-        cache[firClassSymbol].with(firClassSymbol).emitAll(element, Role.REFERENCE, context)
+    context(context: CheckerContext)
+    fun visitCallableReference(firClassSymbol: FirCallableSymbol<*>, element: KtSourceElement) {
+        cache[firClassSymbol].with(firClassSymbol).emitAll(element, Role.REFERENCE)
     }
 
-    fun visitClassOrObject(firClass: FirClassLikeDeclaration, element: KtSourceElement, context: CheckerContext) {
-        cache[firClass.symbol].with(firClass.symbol).emitAll(element, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitClassOrObject(firClass: FirClassLikeDeclaration, element: KtSourceElement) {
+        cache[firClass.symbol].with(firClass.symbol).emitAll(element, Role.DEFINITION)
     }
 
-    fun visitPrimaryConstructor(firConstructor: FirConstructor, source: KtSourceElement, context: CheckerContext) {
+    context(context: CheckerContext)
+    fun visitPrimaryConstructor(firConstructor: FirConstructor, source: KtSourceElement) {
         // if the constructor is not denoted by the 'constructor' keyword, we want to link it to the
         // class ident
-        cache[firConstructor.symbol].with(firConstructor.symbol).emitAll(source, Role.DEFINITION, context)
+        cache[firConstructor.symbol].with(firConstructor.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitSecondaryConstructor(firConstructor: FirConstructor, source: KtSourceElement, context: CheckerContext) {
-        cache[firConstructor.symbol].with(firConstructor.symbol).emitAll(source, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitSecondaryConstructor(firConstructor: FirConstructor, source: KtSourceElement) {
+        cache[firConstructor.symbol].with(firConstructor.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitNamedFunction(firFunction: FirFunction, source: KtSourceElement, context: CheckerContext) {
-        cache[firFunction.symbol].with(firFunction.symbol).emitAll(source, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitNamedFunction(firFunction: FirFunction, source: KtSourceElement) {
+        cache[firFunction.symbol].with(firFunction.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitProperty(firProperty: FirProperty, source: KtSourceElement, context: CheckerContext) {
-        cache[firProperty.symbol].with(firProperty.symbol).emitAll(source, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitProperty(firProperty: FirProperty, source: KtSourceElement) {
+        cache[firProperty.symbol].with(firProperty.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitParameter(firParameter: FirValueParameter, source: KtSourceElement, context: CheckerContext) {
-        cache[firParameter.symbol].with(firParameter.symbol).emitAll(source, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitParameter(firParameter: FirValueParameter, source: KtSourceElement) {
+        cache[firParameter.symbol].with(firParameter.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitTypeParameter(firTypeParameter: FirTypeParameter, source: KtSourceElement, context: CheckerContext) {
+    context(context: CheckerContext)
+    fun visitTypeParameter(firTypeParameter: FirTypeParameter, source: KtSourceElement) {
         cache[firTypeParameter.symbol]
             .with(firTypeParameter.symbol)
-            .emitAll(source, Role.DEFINITION, context)
+            .emitAll(source, Role.DEFINITION)
     }
 
-    fun visitTypeAlias(firTypeAlias: FirTypeAlias, source: KtSourceElement, context: CheckerContext) {
-        cache[firTypeAlias.symbol].with(firTypeAlias.symbol).emitAll(source, Role.DEFINITION, context)
+    context(context: CheckerContext)
+    fun visitTypeAlias(firTypeAlias: FirTypeAlias, source: KtSourceElement) {
+        cache[firTypeAlias.symbol].with(firTypeAlias.symbol).emitAll(source, Role.DEFINITION)
     }
 
-    fun visitPropertyAccessor(firPropertyAccessor: FirPropertyAccessor, source: KtSourceElement, context: CheckerContext) {
+    context(context: CheckerContext)
+    fun visitPropertyAccessor(firPropertyAccessor: FirPropertyAccessor, source: KtSourceElement) {
         cache[firPropertyAccessor.symbol]
             .with(firPropertyAccessor.symbol)
-            .emitAll(source, Role.DEFINITION, context)
+            .emitAll(source, Role.DEFINITION)
     }
 
+    context(context: CheckerContext)
     fun visitSimpleNameExpression(
         firResolvedNamedReference: FirResolvedNamedReference,
-        source: KtSourceElement, context: CheckerContext,
+        source: KtSourceElement,
     ) {
         cache[firResolvedNamedReference.resolvedSymbol]
             .with(firResolvedNamedReference.resolvedSymbol)
-            .emitAll(source, Role.REFERENCE, context)
+            .emitAll(source, Role.REFERENCE)
     }
 }
 

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -483,7 +483,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 80>`#"
+                    symbol = "local1"
                     range {
                         startLine = 7
                         startCharacter = 12
@@ -493,7 +493,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 80>`#`<init>`()."
+                    symbol = "local2"
                     range {
                         startLine = 7
                         startCharacter = 12
@@ -513,7 +513,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 80>`#foo()."
+                    symbol = "local3"
                     range {
                         startLine = 8
                         startCharacter = 21
@@ -523,7 +523,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 149>`#"
+                    symbol = "local5"
                     range {
                         startLine = 10
                         startCharacter = 12
@@ -533,7 +533,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 149>`#`<init>`()."
+                    symbol = "local6"
                     range {
                         startLine = 10
                         startCharacter = 12
@@ -553,7 +553,7 @@ class AnalyzerTest {
                 },
                 SymbolOccurrence {
                     role = Role.DEFINITION
-                    symbol = "sample/`<anonymous object at 149>`#foo()."
+                    symbol = "local7"
                     range {
                         startLine = 11
                         startCharacter = 21
@@ -578,7 +578,7 @@ class AnalyzerTest {
                     }
                 },
                 SymbolInformation {
-                    symbol = "sample/`<anonymous object at 80>`#"
+                    symbol = "local1"
                     displayName = "<anonymous>"
                     language = KOTLIN
                     documentation {
@@ -588,7 +588,7 @@ class AnalyzerTest {
                     addOverriddenSymbols("sample/Interface#")
                 },
                 SymbolInformation {
-                    symbol = "sample/`<anonymous object at 80>`#foo()."
+                    symbol = "local3"
                     displayName = "foo"
                     language = KOTLIN
                     documentation {
@@ -598,7 +598,7 @@ class AnalyzerTest {
                     addOverriddenSymbols("sample/Interface#foo().")
                 },
                 SymbolInformation {
-                    symbol = "sample/`<anonymous object at 149>`#"
+                    symbol = "local5"
                     displayName = "<anonymous>"
                     language = KOTLIN
                     documentation {
@@ -608,7 +608,7 @@ class AnalyzerTest {
                     addOverriddenSymbols("sample/Interface#")
                 },
                 SymbolInformation {
-                    symbol = "sample/`<anonymous object at 149>`#foo()."
+                    symbol = "local7"
                     displayName = "foo"
                     language = KOTLIN
                     documentation {


### PR DESCRIPTION
* CheckerContext.containingFile was renamed to containingFileSymbol.

* FirCallableSymbol<*>.directOverriddenSymbolsSafe now takes context by context parameter.

* FirCallableSymbol.callableId was made nullable and is replaced by FirCallableSymbol.callableIdForRendering for rendering purpose.

* Anonymous objects are now considered as locals.
